### PR TITLE
fix: resolve naming conflict for publishing on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 ## Installation
 
 ```bash
-yarn add tiny-bus
+yarn add tiny-b
 ```
 
 ## Usage
 
 ```typescript
-import TinyBus from "tiny-bus";
+import TinyBus from "tiny-b";
 
 const tinyBus = new TinyBus(/* options */);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "tiny-bus",
+  "name": "tiny-b",
   "license": "MIT",
+  "private": false,
   "description": "A tiny and highly customizable event bus supporting different dispatching strategies.",
   "version": "1.0.0",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

Changed the package name from `tiny-bus` to `tiny-b` because of a conflicting package on npm. This will not be reflected within the code base as the main import still is called `TinyBus`.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
