### PR TITLE
fix: resolve import issues for node.js usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "A tiny and highly customizable event bus supporting different dispatching strategies.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,8 +1,9 @@
 import dts from "bun-plugin-dts";
 
 await Bun.build({
-  entrypoints: ["./index.ts"],
-  outdir: "./dist",
   minify: true,
+  outdir: "./dist",
   plugins: [dts()],
+  entrypoints: ["./index.ts"],
+  naming: { entry: "[name].mjs" },
 });


### PR DESCRIPTION
## Description

This PR fixed the build script to rename the output file to `index.mjs` instead of `index.js` so people using NodeJS can successfully import the package.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
