### PR TITLE
feat: add debug logging functionality

### DIFF
--- a/__tests__/classes/debug-logger.test.ts
+++ b/__tests__/classes/debug-logger.test.ts
@@ -1,0 +1,53 @@
+import { it, expect } from "bun:test";
+
+import DebugLogger from "classes/debug-logger";
+import type { DebugEventName } from "types/debug-logger";
+
+const debugEventNames: DebugEventName[] = [
+  "startReplay",
+  "endReplay",
+  "startEmit",
+  "endEmit",
+  "startSubscribe",
+  "endSubscribe",
+  "startRemove",
+  "endRemove",
+  "startRemoveAll",
+  "endRemoveAll",
+  "startPersist",
+  "endPersist",
+  "startRestore",
+  "endRestore",
+  "startErrorHandler",
+  "endErrorHandler",
+  "startIsUnique",
+  "endIsUnique",
+];
+
+it("Callback is called with correct arguments", () => {
+  const debugLogger = new DebugLogger((debugName, debugId, duration) => {
+    expect(debugEventNames).toContain(debugName);
+    expect(debugId).toBe("test");
+    if (debugName.startsWith("start")) expect(duration).toBeUndefined();
+    else expect(duration).toBeTypeOf("string");
+  });
+
+  debugLogger.startReplay("test");
+  debugLogger.endReplay("test");
+  debugLogger.startEmit("test");
+  debugLogger.endEmit("test");
+  debugLogger.startSubscribe("test");
+  debugLogger.endSubscribe("test");
+  debugLogger.startRemove("test");
+  debugLogger.endRemove("test");
+  debugLogger.startRemoveAll("test");
+  debugLogger.endRemoveAll("test");
+  debugLogger.startPersist("test");
+  debugLogger.endPersist("test");
+  debugLogger.startRestore("test");
+  debugLogger.endRestore("test");
+  debugLogger.startErrorHandler("test");
+  debugLogger.endErrorHandler("test");
+  debugLogger.startIsUnique("test");
+  debugLogger.endIsUnique("test");
+});

--- a/__tests__/utils/console.test.ts
+++ b/__tests__/utils/console.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from "bun:test";
+
+import { c } from "utils/console";
+
+it("Returns correct the text with color", () => {
+  const text = "test";
+  const red = `\x1b[31m${text}\x1b[0m`;
+  const green = `\x1b[32m${text}\x1b[0m`;
+  const yellow = `\x1b[33m${text}\x1b[0m`;
+  const blue = `\x1b[34m${text}\x1b[0m`;
+  const magenta = `\x1b[35m${text}\x1b[0m`;
+  const cyan = `\x1b[36m${text}\x1b[0m`;
+  const white = `\x1b[37m${text}\x1b[0m`;
+  const gray = `\x1b[90m${text}\x1b[0m`;
+  expect(c(text, "red")).toBe(red);
+  expect(c(text, "green")).toBe(green);
+  expect(c(text, "yellow")).toBe(yellow);
+  expect(c(text, "blue")).toBe(blue);
+  expect(c(text, "magenta")).toBe(magenta);
+  expect(c(text, "cyan")).toBe(cyan);
+  expect(c(text, "white")).toBe(white);
+  expect(c(text, "gray")).toBe(gray);
+});

--- a/__tests__/utils/console.test.ts
+++ b/__tests__/utils/console.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from "bun:test";
 
 import { c } from "utils/console";
 
-it("Returns correct the text with color", () => {
+it("Returns the correct color for each color name", () => {
   const text = "test";
   const red = `\x1b[31m${text}\x1b[0m`;
   const green = `\x1b[32m${text}\x1b[0m`;

--- a/classes/debug-logger.ts
+++ b/classes/debug-logger.ts
@@ -1,0 +1,149 @@
+import { c } from "utils/console";
+
+import type {
+  DebugEventCallback,
+  DebugLoggerInterface,
+} from "types/debug-logger";
+
+/**
+ * A class for logging debug events. This class is used internally by TinyBus,
+ * optionally a callback can be provided to log events to a custom logger.
+ */
+export default class DebugLogger implements DebugLoggerInterface {
+  private readonly time = new Map<string, Date>();
+
+  constructor(private readonly callback?: DebugEventCallback) {}
+
+  private getDuration(id: string) {
+    if (!this.time.has(id)) throw new Error(`No start time for ${id}`);
+    const start = this.time.get(id);
+    if (!start) throw new Error(`Invalid start time for ${id}`);
+    const duration = new Date().getTime() - start.getTime();
+    this.time.delete(id);
+    return duration.toFixed(2);
+  }
+
+  startReplay(id: string) {
+    this.time.set(`replay::${id}`, new Date());
+    if (this.callback) return this.callback("startReplay", id);
+    console.log(`${c("[Replay]", "blue")} Started replaying ${id}`);
+  }
+
+  endReplay(id: string) {
+    const duration = this.getDuration(`replay::${id}`);
+    if (this.callback) return this.callback("endReplay", id, duration);
+    console.log(`${c("[Replay]", "blue")} Ended replay ${id} (${duration} ms)`);
+  }
+
+  startEmit(id: string) {
+    this.time.set(`emit::${id}`, new Date());
+    if (this.callback) return this.callback("startEmit", id);
+    console.log(`${c("[Emit]", "green")} Started emitting ${id}`);
+  }
+
+  endEmit(id: string) {
+    const duration = this.getDuration(`emit::${id}`);
+    if (this.callback) return this.callback("endEmit", id, duration);
+    console.log(
+      `${c("[Emit]", "green")} Ended emitting ${id} (${duration} ms)`,
+    );
+  }
+
+  startSubscribe(id: string) {
+    this.time.set(`subscribe::${id}`, new Date());
+    if (this.callback) return this.callback("startSubscribe", id);
+    console.log(`${c("[New]", "yellow")} Started subscribing ${id}`);
+  }
+
+  endSubscribe(id: string) {
+    const duration = this.getDuration(`subscribe::${id}`);
+    if (this.callback) return this.callback("endSubscribe", id, duration);
+    console.log(
+      `${c("[New]", "yellow")} Ended subscribing ${id} (${duration} ms)`,
+    );
+  }
+
+  startRemove(id: string) {
+    this.time.set(`remove::${id}`, new Date());
+    if (this.callback) return this.callback("startRemove", id);
+    console.log(`${c("[End]", "red")} Started removing ${id}`);
+  }
+
+  endRemove(id: string) {
+    const duration = this.getDuration(`remove::${id}`);
+    if (this.callback) return this.callback("endRemove", id, duration);
+    console.log(`${c("[End]", "red")} Ended removing ${id} (${duration} ms)`);
+  }
+
+  startRemoveAll(id: string) {
+    this.time.set(`removeAll::${id}`, new Date());
+    if (this.callback) return this.callback("startRemoveAll", id);
+    console.log(`${c("[Clear]", "magenta")} Started removing all ${id}`);
+  }
+
+  endRemoveAll(id: string) {
+    const duration = this.getDuration(`removeAll::${id}`);
+    if (this.callback) return this.callback("endRemoveAll", id, duration);
+    console.log(
+      `${c("[Clear]", "magenta")} Ended removing all ${id} (${duration} ms)`,
+    );
+  }
+
+  startPersist(id: string) {
+    this.time.set(`persist::${id}`, new Date());
+    if (this.callback) return this.callback("startPersist", id);
+    console.log(`${c("[Replay]", "blue")} Started persisting ${id}`);
+  }
+
+  endPersist(id: string) {
+    const duration = this.getDuration(`persist::${id}`);
+    if (this.callback) return this.callback("endPersist", id, duration);
+    console.log(
+      `${c("[Replay]", "blue")} Ended persisting ${id} (${duration} ms)`,
+    );
+  }
+
+  startRestore(id: string) {
+    this.time.set(`restore::${id}`, new Date());
+    if (this.callback) return this.callback("startRestore", id);
+    console.log(`${c("[Replay]", "blue")} Started restoring ${id}`);
+  }
+
+  endRestore(id: string) {
+    const duration = this.getDuration(`restore::${id}`);
+    if (this.callback) return this.callback("endRestore", id, duration);
+    console.log(
+      `${c("[Replay]", "blue")} Ended restoring ${id} (${duration} ms)`,
+    );
+  }
+
+  startErrorHandler(id: string) {
+    this.time.set(`error::${id}`, new Date());
+    if (this.callback) return this.callback("startErrorHandler", id);
+    console.log(`${c("[Error]", "red")} Started handling error ${id}`);
+  }
+
+  endErrorHandler(id: string) {
+    const duration = this.getDuration(`error::${id}`);
+    if (this.callback) return this.callback("endErrorHandler", id, duration);
+    console.log(
+      `${c("[Error]", "red")} Ended handling error ${id} (${duration} ms)`,
+    );
+  }
+
+  startIsUnique(id: string) {
+    this.time.set(`unique::${id}`, new Date());
+    if (this.callback) return this.callback("startIsUnique", id);
+    console.log(
+      `${c("[Unique]", "cyan")} Started checking if event args for (${id}) are unique`,
+    );
+  }
+
+  endIsUnique(id: string) {
+    const duration = this.getDuration(`unique::${id}`);
+    if (this.callback) return this.callback("endIsUnique", id, duration);
+    console.log(
+      `${c("[Unique]", "cyan")} Ended checking if event args for (${id}) are unique (${duration} ms)`,
+    );
+  }
+}

--- a/classes/tiny-bus.ts
+++ b/classes/tiny-bus.ts
@@ -37,7 +37,7 @@ export default class TinyBus<T extends object = any>
     }
 
     // attach debug logger if debug option is set to true
-    if (this.options?.debug) {
+    if (this.options?.debug || this.options?.onDebug) {
       this.debug = new DebugLogger(this.options?.onDebug);
     }
   }

--- a/classes/tiny-bus.ts
+++ b/classes/tiny-bus.ts
@@ -14,6 +14,7 @@ import type {
 } from "types/tiny-bus";
 
 import EventStore from "classes/event-store";
+import DebugLogger from "classes/debug-logger";
 import PriorityQueue from "classes/priority-queue";
 
 /**
@@ -34,10 +35,16 @@ export default class TinyBus<T extends object = any>
         "If providing a restore or persist function, both must be provided.",
       );
     }
+
+    // attach debug logger if debug option is set to true
+    if (this.options?.debug) {
+      this.debug = new DebugLogger(this.options?.onDebug);
+    }
   }
 
   private store: EventStore<T> = new EventStore<T>();
   private processedEvents = new Set<string>();
+  private debug: DebugLogger | undefined;
 
   private subscribers = new Map<
     EventName,
@@ -47,18 +54,23 @@ export default class TinyBus<T extends object = any>
   private errorHandlers = new Map<EventName, Map<string, EventErrorCallback>>();
 
   public async replay<A extends any[] = any[]>(id: EventID) {
+    this.debug?.startReplay?.(id);
     const event = await this.restore<A>(id);
     if (!event) return;
     await this.emit<A>(
       event.name,
       ...([{ __replay: true, eventId: event.id }, ...(event.args as A)] as A),
     );
+    this.debug?.endReplay?.(id);
   }
 
   public async emit<A extends any[] = any[]>(eventName: EventName, ...args: A) {
     const subscribers = this.subscribers.get(eventName);
     const isReplay = args[0]?.__replay === true;
     const isUnique = isReplay ? true : await this.isUnique(eventName, args);
+
+    // start debug timer if debug is enabled and this is not a replay
+    if (!isReplay) this.debug?.startEmit?.(eventName);
 
     // clean up replay args so they are not passed to subscribers
     if (isReplay) args.shift();
@@ -157,6 +169,7 @@ export default class TinyBus<T extends object = any>
         context: this.options?.context,
       });
 
+      this.debug?.endEmit?.(eventName);
       return eventId;
     }
   }
@@ -165,6 +178,8 @@ export default class TinyBus<T extends object = any>
     eventName: EventName,
     options: EventSubscriberOptions<T, A>,
   ): Promise<SubscriberID> {
+    this.debug?.startSubscribe?.(eventName);
+
     if (!this.subscribers.has(eventName)) {
       this.subscribers.set(
         eventName,
@@ -193,6 +208,7 @@ export default class TinyBus<T extends object = any>
     // call subscribe handler if provided
     await this.options?.onSubscribe?.(eventName, subscriberId);
 
+    this.debug?.endSubscribe?.(eventName);
     return subscriberId;
   }
 
@@ -200,6 +216,7 @@ export default class TinyBus<T extends object = any>
     eventName: EventName,
     subscriberId: string,
   ): Promise<SubscriberID> {
+    this.debug?.startRemove?.(eventName);
     const subscribers = this.subscribers.get(eventName);
 
     if (!subscribers?.size()) {
@@ -231,10 +248,12 @@ export default class TinyBus<T extends object = any>
     // call unsubscribe handler if provided
     await this.options?.onUnsubscribe?.(eventName, subscriberId);
 
+    this.debug?.endRemove?.(eventName);
     return subscriberId;
   }
 
   public async removeAll(eventName: EventName): Promise<EventName> {
+    this.debug?.startRemove?.(eventName);
     const subscribers = this.subscribers.get(eventName);
 
     if (!subscribers?.size()) {
@@ -250,16 +269,20 @@ export default class TinyBus<T extends object = any>
     subscribers.clear();
     this.errorHandlers.delete(eventName);
 
+    this.debug?.endRemove?.(eventName);
     return eventName;
   }
 
   private async isUnique(eventName: EventName, args: any[]): Promise<boolean> {
     // if unique events is disabled, return true
     if (this.options?.uniqueEvents === false) return true;
+    this.debug?.startIsUnique?.(eventName);
 
     // call onUniqueCheck handler if provided
     if (this.options?.onUniqueCheck) {
-      return await this.options.onUniqueCheck(eventName, args);
+      const result = await this.options.onUniqueCheck(eventName, args);
+      this.debug?.endIsUnique?.(eventName);
+      return result;
     }
 
     const eventId = Buffer.from(
@@ -269,6 +292,7 @@ export default class TinyBus<T extends object = any>
     const isUnique = !this.processedEvents.has(eventId);
     if (isUnique) this.processedEvents.add(eventId);
 
+    this.debug?.endIsUnique?.(eventName);
     return isUnique;
   }
 
@@ -277,11 +301,13 @@ export default class TinyBus<T extends object = any>
     subscriberId: SubscriberID,
     error: E,
   ) {
+    this.debug?.startErrorHandler?.(eventName);
     const errorHandlers = this.errorHandlers.get(eventName);
     if (!errorHandlers?.size) return;
     const handler = errorHandlers.get(subscriberId);
     if (!handler) throw error;
     handler({ error, eventName, subscriberId });
+    this.debug?.endErrorHandler?.(eventName);
   }
 
   private async wait() {
@@ -293,15 +319,19 @@ export default class TinyBus<T extends object = any>
   private async persist<A extends any[] = any[]>(
     event: Omit<TinyBusEvent<T, A>, "id">,
   ): Promise<EventID> {
-    return (
+    this.debug?.startPersist?.(event.name);
+    const result =
       (await this.options?.onPersist<A>?.(event)) ??
-      this.store.persist<A>(event)
-    );
+      this.store.persist<A>(event);
+    this.debug?.endPersist?.(event.name);
+    return result;
   }
 
   private async restore<A extends any[] = any[]>(id: EventID) {
-    return (
-      (await this.options?.onRestore<A>?.(id)) ?? this.store.restore<A>(id)
-    );
+    this.debug?.startRestore?.(id);
+    const result =
+      (await this.options?.onRestore<A>?.(id)) ?? this.store.restore<A>(id);
+    this.debug?.endRestore?.(id);
+    return result;
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "A tiny and highly customizable event bus supporting different dispatching strategies.",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [

--- a/types/debug-logger.ts
+++ b/types/debug-logger.ts
@@ -1,6 +1,6 @@
 export type DebugEventCallback = (
-  name: DebugEventName,
-  id: string,
+  debugEventName: DebugEventName,
+  debugEventId: string,
   duration?: string,
 ) => void;
 

--- a/types/debug-logger.ts
+++ b/types/debug-logger.ts
@@ -1,0 +1,100 @@
+export type DebugEventCallback = (
+  name: DebugEventName,
+  id: string,
+  duration?: string,
+) => void;
+
+export type DebugEventName =
+  | "startReplay"
+  | "endReplay"
+  | "startEmit"
+  | "endEmit"
+  | "startSubscribe"
+  | "endSubscribe"
+  | "startRemove"
+  | "endRemove"
+  | "startRemoveAll"
+  | "endRemoveAll"
+  | "startPersist"
+  | "endPersist"
+  | "startRestore"
+  | "endRestore"
+  | "startErrorHandler"
+  | "endErrorHandler"
+  | "startIsUnique"
+  | "endIsUnique";
+
+export interface DebugLoggerInterface {
+  /**
+   * Called when a event replay starts.
+   */
+  startReplay: (id: string) => void;
+  /**
+   * Called when a event is restored for replay.
+   */
+  startRestore: (id: string) => void;
+  /**
+   * Called when a event replay has been restored.
+   */
+  endRestore: (id: string) => void;
+  /**
+   * Called when a event replay ends.
+   */
+  endReplay: (id: string) => void;
+  /**
+   * Called a event starts to be emitted.
+   */
+  startEmit: (id: string) => void;
+  /**
+   * Called when a event has been emitted.
+   */
+  endEmit: (id: string) => void;
+  /**
+   * Called when a event starts to be subscribed to.
+   */
+  startSubscribe: (id: string) => void;
+  /**
+   * Called when a event has been subscribed to.
+   */
+  endSubscribe: (id: string) => void;
+  /**
+   * Called when a subscriber starts to be removed.
+   */
+  startRemove: (id: string) => void;
+  /**
+   * Called when a subscriber has been removed.
+   */
+  endRemove: (id: string) => void;
+  /**
+   * Called when all subscribers start to be removed.
+   */
+  startRemoveAll: (id: string) => void;
+  /**
+   * Called when all subscribers have been removed.
+   */
+  endRemoveAll: (id: string) => void;
+  /**
+   * Called when a event starts to be persisted for replay.
+   */
+  startPersist: (id: string) => void;
+  /**
+   * Called when a event has been persisted for replay.
+   */
+  endPersist: (id: string) => void;
+  /**
+   * Called when a error handler starts to be called.
+   */
+  startErrorHandler: (id: string) => void;
+  /**
+   * Called when a error handler has been called.
+   */
+  endErrorHandler: (id: string) => void;
+  /**
+   * Called when a event starts to be checked for uniqueness.
+   */
+  startIsUnique: (id: string) => void;
+  /**
+   * Called when a event has been checked for uniqueness.
+   */
+  endIsUnique: (id: string) => void;
+}

--- a/types/tiny-bus.ts
+++ b/types/tiny-bus.ts
@@ -1,3 +1,5 @@
+import type { DebugEventCallback } from "types/debug-logger";
+
 export type EventID = string;
 export type EventName = string;
 export type SubscriberID = string;
@@ -63,6 +65,16 @@ export interface TinyBusInterface<T extends object = any> {
 }
 
 export interface TinyBusOptions<T extends object = any> {
+  /**
+   * If set to true, the event bus will log debug information for all
+   * events emitted. Defaults to false.
+   */
+  debug?: boolean;
+  /**
+   * Called to replace the default debug logger. If not provided, the default
+   * debug logger will be used.
+   */
+  onDebug?: DebugEventCallback;
   /**
    * The context of the subscriber that emitted the event.
    */

--- a/utils/console.ts
+++ b/utils/console.ts
@@ -1,0 +1,36 @@
+/**
+ * Log a message to the console with a color.
+ */
+export const c = (
+  text: string,
+  color:
+    | "red"
+    | "gray"
+    | "green"
+    | "yellow"
+    | "blue"
+    | "magenta"
+    | "cyan"
+    | "white",
+) => {
+  switch (color) {
+    case "red":
+      return `\x1b[31m${text}\x1b[0m`;
+    case "green":
+      return `\x1b[32m${text}\x1b[0m`;
+    case "yellow":
+      return `\x1b[33m${text}\x1b[0m`;
+    case "blue":
+      return `\x1b[34m${text}\x1b[0m`;
+    case "magenta":
+      return `\x1b[35m${text}\x1b[0m`;
+    case "cyan":
+      return `\x1b[36m${text}\x1b[0m`;
+    case "white":
+      return `\x1b[37m${text}\x1b[0m`;
+    case "gray":
+      return `\x1b[90m${text}\x1b[0m`;
+    default:
+      return text;
+  }
+};


### PR DESCRIPTION
## Description

This PR adds debug logging to all methods of the `TinyBus` class. You can either enable it by setting the `debug` flag in the constructor or by providing a `onDebug` callback function.

```typescript
import TinyBus from "tiny-b";

// use the default logger
const debugBus = new TinyBus({ debug: true });

// or provide your own logger function
const customDebugBus = new TinyBus({
  onDebug: (debugEventName, debugEventId, duration) => {
    console.log(debugEventName, debugEventId, duration);
  },
});
```

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added tests for the new debug logging feature.

- [x] Callback is called with correct arguments
- [x] Returns the correct color for each color name

### Test Configuration

- OS: MacOS 14.3 (23D56)
- Bun version: v1.0.25

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
